### PR TITLE
refactor: update network configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,15 @@ resource "azurerm_servicebus_namespace" "this" {
 
   public_network_access_enabled = var.public_network_access_enabled
 
+  dynamic "identity" {
+    for_each = local.identity_type != "" ? [1] : []
+
+    content {
+      type         = local.identity_type
+      identity_ids = var.identity_ids
+    }
+  }
+
   dynamic "network_rule_set" {
     # Conditionally define the entire network_rule_set block based on SKU
     for_each = var.sku == "Premium" ? [1] : []
@@ -38,15 +47,6 @@ resource "azurerm_servicebus_namespace" "this" {
           ignore_missing_vnet_service_endpoint = network_rules.value["ignore_missing_vnet_service_endpoint"]
         }
       }
-    }
-  }
-
-  dynamic "identity" {
-    for_each = local.identity_type != "" ? [1] : []
-
-    content {
-      type         = local.identity_type
-      identity_ids = var.identity_ids
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -25,13 +25,13 @@ resource "azurerm_servicebus_namespace" "this" {
 
     content {
       public_network_access_enabled = var.public_network_access_enabled
-      default_action                = length(var.network_rule_set_ip_rules) == 0 && length(var.network_rules) == 0 ? "Allow" : "Deny"
-      trusted_services_allowed      = var.network_rule_set_trusted_services_allowed
+      default_action                = length(var.network_rule_set_ip_rules) == 0 && length(var.network_rule_set_virtual_network_rules) == 0 ? "Allow" : "Deny"
       ip_rules                      = var.network_rule_set_ip_rules
+      trusted_services_allowed      = var.network_rule_set_trusted_services_allowed
 
       # Conditionally define multiple network_rules inside the network_rule_set
       dynamic "network_rules" {
-        for_each = var.network_rules
+        for_each = var.network_rule_set_virtual_network_rules
 
         content {
           subnet_id                            = network_rules.value["subnet_id"]

--- a/main.tf
+++ b/main.tf
@@ -30,10 +30,10 @@ resource "azurerm_servicebus_namespace" "this" {
     # Conditionally define the entire network_rule_set block based on SKU and enable_network_rule_set
     for_each = var.sku == "Premium" && var.enable_network_rule_set ? [1] : []
     content {
-      default_action                = var.network_default_action
-      public_network_access_enabled = var.network_public_network_access_enabled
-      trusted_services_allowed      = var.network_trusted_services_allowed
-      ip_rules                      = var.network_ip_rules
+      default_action                = var.network_rule_set_default_action
+      public_network_access_enabled = var.network_rule_set_public_network_access_enabled
+      trusted_services_allowed      = var.network_rule_set_trusted_services_allowed
+      ip_rules                      = var.network_rule_set_ip_rules
 
       # Conditionally define multiple network_rules inside the network_rule_set
       dynamic "network_rules" {

--- a/main.tf
+++ b/main.tf
@@ -30,8 +30,8 @@ resource "azurerm_servicebus_namespace" "this" {
     # Conditionally define the entire network_rule_set block based on SKU and enable_network_rule_set
     for_each = var.sku == "Premium" ? [0] : []
     content {
+      public_network_access_enabled = var.public_network_access_enabled
       default_action                = var.network_rule_set_default_action
-      public_network_access_enabled = var.network_rule_set_public_network_access_enabled
       trusted_services_allowed      = var.network_rule_set_trusted_services_allowed
       ip_rules                      = var.network_rule_set_ip_rules
 

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "azurerm_servicebus_namespace" "this" {
 
   dynamic "network_rule_set" {
     # Conditionally define the entire network_rule_set block based on SKU and enable_network_rule_set
-    for_each = var.sku == "Premium" && var.enable_network_rule_set ? [1] : []
+    for_each = var.sku == "Premium" ? [0] : []
     content {
       default_action                = var.network_rule_set_default_action
       public_network_access_enabled = var.network_rule_set_public_network_access_enabled

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "azurerm_servicebus_namespace" "this" {
 
     content {
       public_network_access_enabled = var.public_network_access_enabled
-      default_action                = var.network_rule_set_default_action
+      default_action                = length(var.network_rule_set_ip_rules) == 0 && length(var.network_rules) == 0 ? "Allow" : "Deny"
       trusted_services_allowed      = var.network_rule_set_trusted_services_allowed
       ip_rules                      = var.network_rule_set_ip_rules
 

--- a/variables.tf
+++ b/variables.tf
@@ -51,19 +51,13 @@ variable "identity_ids" {
   default     = []
 }
 
-variable "network_rule_set_trusted_services_allowed" {
-  description = "Azure Services that are known and trusted for this resource type are allowed to bypass firewall configuration"
-  type        = bool
-  default     = true
-}
-
 variable "network_rule_set_ip_rules" {
   description = "One or more IP Addresses, or CIDR Blocks which should be able to access the ServiceBus Namespace."
   type        = list(string)
   default     = []
 }
 
-variable "network_rules" {
+variable "network_rule_set_virtual_network_rules" {
   description = "Conditionally define multiple network_rules inside the network_rule_set"
 
   type = list(object({
@@ -72,6 +66,12 @@ variable "network_rules" {
   }))
 
   default = []
+}
+
+variable "network_rule_set_trusted_services_allowed" {
+  description = "Azure Services that are known and trusted for this resource type are allowed to bypass firewall configuration"
+  type        = bool
+  default     = true
 }
 
 variable "log_analytics_workspace_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -49,13 +49,6 @@ variable "identity_ids" {
   default     = []
 }
 
-# network (Private access is only available on Premium namespaces.)
-variable "enable_network_rule_set" {
-  description = "Should the network rule set be enabled for this Service Bus namespace?"
-  type        = bool
-  default     = false # Default to false as it is only available on Premium namespaces
-}
-
 variable "network_rule_set_default_action" {
   description = "Specifies the default action for the Network Rule Set. Possible values are Allow and Deny."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -56,25 +56,25 @@ variable "enable_network_rule_set" {
   default     = false # Default to false as it is only available on Premium namespaces
 }
 
-variable "network_default_action" {
+variable "network_rule_set_default_action" {
   description = "Specifies the default action for the Network Rule Set. Possible values are Allow and Deny."
   type        = string
   default     = "Allow" # Or Deny??
 }
 
-variable "network_public_network_access_enabled" {
+variable "network_rule_set_public_network_access_enabled" {
   description = "Whether to allow traffic over public network. Possible values are true and false."
   type        = bool
   default     = true
 }
 
-variable "network_trusted_services_allowed" {
+variable "network_rule_set_trusted_services_allowed" {
   description = "Azure Services that are known and trusted for this resource type are allowed to bypass firewall configuration"
   type        = bool
   default     = true
 }
 
-variable "network_ip_rules" {
+variable "network_rule_set_ip_rules" {
   description = "One or more IP Addresses, or CIDR Blocks which should be able to access the ServiceBus Namespace."
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -51,12 +51,6 @@ variable "identity_ids" {
   default     = []
 }
 
-variable "network_rule_set_default_action" {
-  description = "Specifies the default action for the Network Rule Set. Possible values are Allow and Deny."
-  type        = string
-  default     = "Deny"
-}
-
 variable "network_rule_set_trusted_services_allowed" {
   description = "Azure Services that are known and trusted for this resource type are allowed to bypass firewall configuration"
   type        = bool
@@ -71,10 +65,12 @@ variable "network_rule_set_ip_rules" {
 
 variable "network_rules" {
   description = "Conditionally define multiple network_rules inside the network_rule_set"
+
   type = list(object({
     subnet_id                            = string
     ignore_missing_vnet_service_endpoint = bool # Originally defaults to false if not defined
   }))
+
   default = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -55,12 +55,6 @@ variable "network_rule_set_default_action" {
   default     = "Allow" # Or Deny??
 }
 
-variable "network_rule_set_public_network_access_enabled" {
-  description = "Whether to allow traffic over public network. Possible values are true and false."
-  type        = bool
-  default     = true
-}
-
 variable "network_rule_set_trusted_services_allowed" {
   description = "Azure Services that are known and trusted for this resource type are allowed to bypass firewall configuration"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "network_rule_set_virtual_network_rules" {
 
   type = list(object({
     subnet_id                            = string
-    ignore_missing_vnet_service_endpoint = bool # Originally defaults to false if not defined
+    ignore_missing_vnet_service_endpoint = optional(bool, false)
   }))
 
   default = []

--- a/variables.tf
+++ b/variables.tf
@@ -22,13 +22,15 @@ variable "sku" {
 variable "capacity" {
   description = "Specifies the capacity. Premium allows 1, 2, 4, 8 or 16. Basic or Standard allows 0 only."
   type        = number
-  default     = 0
+  default     = 1
+  nullable    = false
 }
 
 variable "premium_messaging_partitions" {
   description = "Only valid when sku is Premium and the minimum number is 1. Possible values include 0, 1, 2, and 4. Defaults to 0"
   type        = number
-  default     = 0
+  default     = 1
+  nullable    = false
 }
 
 variable "public_network_access_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "identity_ids" {
 variable "network_rule_set_default_action" {
   description = "Specifies the default action for the Network Rule Set. Possible values are Allow and Deny."
   type        = string
-  default     = "Allow" # Or Deny??
+  default     = "Deny"
 }
 
 variable "network_rule_set_trusted_services_allowed" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     azurerm = {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0.0"
+      version = ">= 3.71.0"
     }
   }
 }


### PR DESCRIPTION
* Automatically set value of argument `capacity` to 0 if value of `sku` is not `"Premium"`.
* Automatically set value of argument `premium_messaging_partitions` to 0 if value of `sku` is not `"Premium"`.
* Remove variable `network_default_action`. The value of the corresponding argument can be automatically set based on other variables.
* Remove variable `network_public_network_access_enabled`. The value of the corresponding argument can be automatically set based on other variables.
* Rename variable `network_trusted_services_allowed` to `network_rule_set_trusted_services_allowed` according to naming convention.
* Rename variable `network_ip_rules` to `network_rule_set_ip_rules` according to naming convention.
* Rename variable `network_rules` to `network_rule_set_virtual_network_rules` according to naming convention. Variable name is based on the corresponding property in the official [ARM template documentation](https://learn.microsoft.com/en-us/azure/templates/microsoft.servicebus/namespaces/networkrulesets?pivots=deployment-language-bicep#networkrulesetproperties), which I think has a more descriptive name than the corresponding block in the [Azure provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/servicebus_namespace#network_rules).
* Set required Terraform version to v1.3, which is required for optional object properties.
* Set required Azure provider version to v3.71, which is required to configure the `network_rule_set` block.