### PR TITLE
fix: disable public network access by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Terraform module which creates Azure Service Bus resources.
 ## Features
 
 - Microsoft Entra authentication enforced by default.
-- Public network access denied by default.
+- Public network access disabled by default.
 - Audit logs sent to given Log Analytics workspace by default.
 
 ## Development

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
-  # If 'system_assigned_identity_enabled' is true, value is "SystemAssigned".
-  # If 'identity_ids' is non-empty, value is "UserAssigned".
-  # If 'system_assigned_identity_enabled' is true and 'identity_ids' is non-empty, value is "SystemAssigned, UserAssigned".
+  # If system_assigned_identity_enabled is true, value is "SystemAssigned".
+  # If identity_ids is non-empty, value is "UserAssigned".
+  # If system_assigned_identity_enabled is true and identity_ids is non-empty, value is "SystemAssigned, UserAssigned".
   identity_type = join(", ", compact([var.system_assigned_identity_enabled ? "SystemAssigned" : "", length(var.identity_ids) > 0 ? "UserAssigned" : ""]))
 
   diagnostic_setting_metric_categories = ["AllMetrics"]

--- a/main.tf
+++ b/main.tf
@@ -23,9 +23,10 @@ resource "azurerm_servicebus_namespace" "this" {
     for_each = var.sku == "Premium" ? [0] : []
 
     content {
+      public_network_access_enabled = var.public_network_access_enabled
+
       # The 'default_action' can only be set to "Allow" if no 'ip_rules' or 'network_rules' is set.
       default_action                = length(var.network_rule_set_ip_rules) == 0 && length(var.network_rule_set_virtual_network_rules) == 0 ? "Allow" : "Deny"
-      public_network_access_enabled = var.public_network_access_enabled
       ip_rules                      = var.network_rule_set_ip_rules
       trusted_services_allowed      = var.network_rule_set_trusted_services_allowed
 

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,4 @@
 locals {
-  # The 'public_network_access_enabled' should only be set to true if 'network_rule_set_ip_rules' or 'network_rule_set_virtual_network_rules' is non-empty.
-  public_network_access_enabled = length(var.network_rule_set_ip_rules) > 0 || length(var.network_rule_set_virtual_network_rules) > 0
-
-  # The 'default_action' can only be set to "Allow" if no 'ip_rules' or 'network_rules' is set.
-  network_rule_set_default_action = length(var.network_rule_set_ip_rules) == 0 && length(var.network_rule_set_virtual_network_rules) == 0 ? "Allow" : "Deny"
-
   # If 'system_assigned_identity_enabled' is true, value is "SystemAssigned".
   # If 'identity_ids' is non-empty, value is "UserAssigned".
   # If 'system_assigned_identity_enabled' is true and 'identity_ids' is non-empty, value is "SystemAssigned, UserAssigned".
@@ -23,14 +17,15 @@ resource "azurerm_servicebus_namespace" "this" {
   premium_messaging_partitions = var.sku == "Premium" ? var.premium_messaging_partitions : 0
 
   local_auth_enabled            = var.local_auth_enabled
-  public_network_access_enabled = local.public_network_access_enabled
+  public_network_access_enabled = var.public_network_access_enabled
 
   dynamic "network_rule_set" {
     for_each = var.sku == "Premium" ? [0] : []
 
     content {
-      default_action                = local.network_rule_set_default_action
-      public_network_access_enabled = local.public_network_access_enabled
+      # The 'default_action' can only be set to "Allow" if no 'ip_rules' or 'network_rules' is set.
+      default_action                = length(var.network_rule_set_ip_rules) == 0 && length(var.network_rule_set_virtual_network_rules) == 0 ? "Allow" : "Deny"
+      public_network_access_enabled = var.public_network_access_enabled
       ip_rules                      = var.network_rule_set_ip_rules
       trusted_services_allowed      = var.network_rule_set_trusted_services_allowed
 

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,13 @@
 locals {
+  # The 'public_network_access_enabled' should only be set to true if 'network_rule_set_ip_rules' or 'network_rule_set_virtual_network_rules' is non-empty.
+  public_network_access_enabled = length(var.network_rule_set_ip_rules) > 0 || length(var.network_rule_set_virtual_network_rules) > 0
+
   # The 'default_action' can only be set to "Allow" if no 'ip_rules' or 'network_rules' is set.
   network_rule_set_default_action = length(var.network_rule_set_ip_rules) == 0 && length(var.network_rule_set_virtual_network_rules) == 0 ? "Allow" : "Deny"
 
-  # TODO(@hknutsen): write a description
-  public_network_access_enabled = length(var.network_rule_set_ip_rules) > 0 || length(var.network_rule_set_virtual_network_rules) > 0
-
-  # If system_assigned_identity_enabled is true, value is "SystemAssigned".
-  # If identity_ids is non-empty, value is "UserAssigned".
-  # If system_assigned_identity_enabled is true and identity_ids is non-empty, value is "SystemAssigned, UserAssigned".
+  # If 'system_assigned_identity_enabled' is true, value is "SystemAssigned".
+  # If 'identity_ids' is non-empty, value is "UserAssigned".
+  # If 'system_assigned_identity_enabled' is true and 'identity_ids' is non-empty, value is "SystemAssigned, UserAssigned".
   identity_type = join(", ", compact([var.system_assigned_identity_enabled ? "SystemAssigned" : "", length(var.identity_ids) > 0 ? "UserAssigned" : ""]))
 
   diagnostic_setting_metric_categories = ["AllMetrics"]

--- a/main.tf
+++ b/main.tf
@@ -26,9 +26,9 @@ resource "azurerm_servicebus_namespace" "this" {
       public_network_access_enabled = var.public_network_access_enabled
 
       # The 'default_action' can only be set to "Allow" if no 'ip_rules' or 'network_rules' is set.
-      default_action                = length(var.network_rule_set_ip_rules) == 0 && length(var.network_rule_set_virtual_network_rules) == 0 ? "Allow" : "Deny"
-      ip_rules                      = var.network_rule_set_ip_rules
-      trusted_services_allowed      = var.network_rule_set_trusted_services_allowed
+      default_action           = length(var.network_rule_set_ip_rules) == 0 && length(var.network_rule_set_virtual_network_rules) == 0 ? "Allow" : "Deny"
+      ip_rules                 = var.network_rule_set_ip_rules
+      trusted_services_allowed = var.network_rule_set_trusted_services_allowed
 
       dynamic "network_rules" {
         for_each = var.network_rule_set_virtual_network_rules

--- a/tests/networking.unit.tftest.hcl
+++ b/tests/networking.unit.tftest.hcl
@@ -53,12 +53,17 @@ run "premium_sku" {
   }
 
   assert {
+    condition     = azurerm_servicebus_namespace.this.public_network_access_enabled == false
+    error_message = "Invalid public network access"
+  }
+
+  assert {
     condition     = azurerm_servicebus_namespace.this.network_rule_set[0].public_network_access_enabled == false
     error_message = "Invalid network rule set public network access"
   }
 
   assert {
-    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].default_action == "Deny"
+    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].default_action == "Allow"
     error_message = "Invalid network rule set default action"
   }
 
@@ -78,76 +83,6 @@ run "premium_sku" {
   }
 }
 
-run "public_network_access_disabled" {
-  command = plan
-
-  variables {
-    namespace_name             = run.setup_tests.namespace_name
-    resource_group_name        = run.setup_tests.resource_group_name
-    location                   = run.setup_tests.location
-    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
-
-    sku = "Premium"
-
-    public_network_access_enabled = false
-  }
-
-  assert {
-    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].public_network_access_enabled == false
-    error_message = "Invalid network rule set public network access"
-  }
-
-  assert {
-    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].default_action == "Deny"
-    error_message = "Invalid network rule set default action"
-  }
-
-  assert {
-    condition     = length(azurerm_servicebus_namespace.this.network_rule_set[0].ip_rules) == 0
-    error_message = "Invalid number of network rule set IP rules"
-  }
-
-  assert {
-    condition     = length(azurerm_servicebus_namespace.this.network_rule_set[0].network_rules) == 0
-    error_message = "Invalid number of network rule set virtual network rules"
-  }
-}
-
-run "network_rule_set_default_action" {
-  command = plan
-
-  variables {
-    namespace_name             = run.setup_tests.namespace_name
-    resource_group_name        = run.setup_tests.resource_group_name
-    location                   = run.setup_tests.location
-    log_analytics_workspace_id = run.setup_tests.log_analytics_workspace_id
-
-    sku = "Premium"
-
-    network_rule_set_default_action = "Allow"
-  }
-
-  assert {
-    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].public_network_access_enabled == true
-    error_message = "Invalid network rule set public network access"
-  }
-
-  assert {
-    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].default_action == "Allow"
-    error_message = "Invalid network rule set default action"
-  }
-
-  assert {
-    condition     = length(azurerm_servicebus_namespace.this.network_rule_set[0].ip_rules) == 0
-    error_message = "Invalid number of network rule set IP rules"
-  }
-
-  assert {
-    condition     = length(azurerm_servicebus_namespace.this.network_rule_set[0].network_rules) == 0
-    error_message = "Invalid number of network rule set virtual network rules"
-  }
-}
-
 run "network_rule_set_ip_rules" {
   command = plan
 
@@ -160,6 +95,11 @@ run "network_rule_set_ip_rules" {
     sku = "Premium"
 
     network_rule_set_ip_rules = ["1.1.1.1/32", "2.2.2.2/32", "3.3.3.3/31"]
+  }
+
+  assert {
+    condition     = azurerm_servicebus_namespace.this.public_network_access_enabled == true
+    error_message = "Invalid public network access"
   }
 
   assert {
@@ -208,6 +148,11 @@ run "network_rule_set_virtual_network_rules" {
   }
 
   assert {
+    condition     = azurerm_servicebus_namespace.this.public_network_access_enabled == true
+    error_message = "Invalid public network access"
+  }
+
+  assert {
     condition     = azurerm_servicebus_namespace.this.network_rule_set[0].public_network_access_enabled == true
     error_message = "Invalid network rule set public network access"
   }
@@ -243,12 +188,17 @@ run "network_rule_set_trusted_services_allowed" {
   }
 
   assert {
+    condition     = azurerm_servicebus_namespace.this.public_network_access_enabled == false
+    error_message = "Invalid public network access"
+  }
+
+  assert {
     condition     = azurerm_servicebus_namespace.this.network_rule_set[0].public_network_access_enabled == false
     error_message = "Invalid network rule set public network access"
   }
 
   assert {
-    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].default_action == "Deny"
+    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].default_action == "Allow"
     error_message = "Invalid network rule set default action"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -54,13 +54,6 @@ variable "premium_messaging_partitions" {
   }
 }
 
-variable "public_network_access_enabled" {
-  description = "Is public network access enabled for the Service Bus namespace? Only applicable if value of sku is \"Premium\"."
-  type        = bool
-  default     = true
-  nullable    = false
-}
-
 variable "system_assigned_identity_enabled" {
   description = "Should the system-assigned identity be enabled for this Service Bus namespace?"
   type        = bool
@@ -73,17 +66,6 @@ variable "identity_ids" {
   type        = list(string)
   default     = []
   nullable    = false
-}
-
-variable "network_rule_set_default_action" {
-  description = "The default action for the network rule set of this Service Bus namespace. Value must be \"Allow\" or \"Deny\"."
-  type        = string
-  default     = "Deny"
-
-  validation {
-    condition     = contains(["Allow", "Deny"], var.network_rule_set_default_action)
-    error_message = "Network rule set default action must be \"Allow\" or \"Deny\"."
-  }
 }
 
 variable "network_rule_set_ip_rules" {

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,13 @@ variable "premium_messaging_partitions" {
   }
 }
 
+variable "public_network_access_enabled" {
+  description = "Is public network access enabled for the Service Bus namespace?"
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
 variable "system_assigned_identity_enabled" {
   description = "Should the system-assigned identity be enabled for this Service Bus namespace?"
   type        = bool


### PR DESCRIPTION
v1.4 of this module throws an error when using its default input values.

The network implementation in this module was based on working network implementations in other modules, such as the [Azure Key Vault](https://github.com/equinor/terraform-azurerm-key-vault/blob/f9b1997e1e88abb775174b67004c93072b7bfc47/variables.tf#L63-L96) and [Azure Storage](https://github.com/equinor/terraform-azurerm-storage/blob/43f8a87ea7441913a8b1f141b1f33962c75e0769/variables.tf#L239-L280) modules, where we **enable** but **deny** public network access by default.

This approach does not seem to work in this module. Instead, we **disable** public network access by default.

Configuration, tests and documentation have been updated accordingly.

This error could not be caught until the apply stage, and thus was not caught by our tests.

Closes equinor/terraform-baseline#186