### PR TITLE
fix: allow IP rules configuration for all SKUs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_servicebus_namespace" "this" {
   network_rule_set {
     public_network_access_enabled = var.public_network_access_enabled
 
-    # The 'default_action' can only be set to "Allow" if no 'ip_rules' or 'network_rules' is set.
+    # The only allowed value for 'default_action' is "Allow" if no 'ip_rules' or 'network_rules' is set.
     default_action           = length(var.network_rule_set_ip_rules) == 0 && length(var.network_rule_set_virtual_network_rules) == 0 ? "Allow" : "Deny"
     ip_rules                 = var.network_rule_set_ip_rules
     trusted_services_allowed = var.network_rule_set_trusted_services_allowed

--- a/tests/networking.unit.tftest.hcl
+++ b/tests/networking.unit.tftest.hcl
@@ -22,8 +22,28 @@ run "basic_sku" {
   }
 
   assert {
-    condition     = length(azurerm_servicebus_namespace.this.network_rule_set) == 0
-    error_message = "Network rule set block created when it should not have been"
+    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].public_network_access_enabled == false
+    error_message = "Invalid network rule set public network access"
+  }
+
+  assert {
+    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].default_action == "Allow"
+    error_message = "Invalid network rule set default action"
+  }
+
+  assert {
+    condition     = length(azurerm_servicebus_namespace.this.network_rule_set[0].ip_rules) == 0
+    error_message = "Invalid number of network rule set IP rules"
+  }
+
+  assert {
+    condition     = length(azurerm_servicebus_namespace.this.network_rule_set[0].network_rules) == 0
+    error_message = "Invalid number of network rule set virtual network rules"
+  }
+
+  assert {
+    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].trusted_services_allowed == true
+    error_message = "Invalid network rule set trusted services"
   }
 }
 
@@ -45,8 +65,28 @@ run "standard_sku" {
   }
 
   assert {
-    condition     = length(azurerm_servicebus_namespace.this.network_rule_set) == 0
-    error_message = "Network rule set block created when it should not have been"
+    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].public_network_access_enabled == false
+    error_message = "Invalid network rule set public network access"
+  }
+
+  assert {
+    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].default_action == "Allow"
+    error_message = "Invalid network rule set default action"
+  }
+
+  assert {
+    condition     = length(azurerm_servicebus_namespace.this.network_rule_set[0].ip_rules) == 0
+    error_message = "Invalid number of network rule set IP rules"
+  }
+
+  assert {
+    condition     = length(azurerm_servicebus_namespace.this.network_rule_set[0].network_rules) == 0
+    error_message = "Invalid number of network rule set virtual network rules"
+  }
+
+  assert {
+    condition     = azurerm_servicebus_namespace.this.network_rule_set[0].trusted_services_allowed == true
+    error_message = "Invalid network rule set trusted services"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -76,7 +76,7 @@ variable "identity_ids" {
 }
 
 variable "network_rule_set_ip_rules" {
-  description = "A list of public IP addresses or ranges that should be able to bypass the network rule set for this Service Bus namespace. Values must be in CIDR format. Only applicable if value of sku is \"Premium\"."
+  description = "A list of public IP addresses or ranges that should be able to bypass the network rule set for this Service Bus namespace. Values must be in CIDR format."
   type        = list(string)
   default     = []
   nullable    = false
@@ -95,7 +95,7 @@ variable "network_rule_set_virtual_network_rules" {
 }
 
 variable "network_rule_set_trusted_services_allowed" {
-  description = "Should Azure services be allowed to bypass the network rule set for this Service Bus namespace? Only applicable if value of sku is \"Premium\"."
+  description = "Should Azure services be allowed to bypass the network rule set for this Service Bus namespace?"
   type        = bool
   default     = true
   nullable    = false


### PR DESCRIPTION
We previously restricted configuration of IP rules to the Premium SKU only, based on an incorrect understanding that network rules were only supported for the Premium SKU.

According to [this document](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-ip-filtering#important-points) however, only **virtual network rules** are restricted to the Premium SKU.

Update module to allow network configuration for all SKUs (Basic, Standard and Premium).

Update tests accordingly.
