### PR TITLE
feat: implicitly enable public network access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,8 @@
 locals {
+  # If public network access is not explicitly enabled or disabled, it should be implicitly enabled if one or more IP or virtual network rules are configured.
+  # This is because public network access must be enabled for IP and virtual network rules to be configured.
+  public_network_access_enabled = coalesce(var.public_network_access_enabled, length(var.network_rule_set_ip_rules) > 0 || length(var.network_rule_set_virtual_network_rules) > 0)
+
   # If system_assigned_identity_enabled is true, value is "SystemAssigned".
   # If identity_ids is non-empty, value is "UserAssigned".
   # If system_assigned_identity_enabled is true and identity_ids is non-empty, value is "SystemAssigned, UserAssigned".
@@ -17,10 +21,10 @@ resource "azurerm_servicebus_namespace" "this" {
   premium_messaging_partitions = var.sku == "Premium" ? var.premium_messaging_partitions : 0
 
   local_auth_enabled            = var.local_auth_enabled
-  public_network_access_enabled = var.public_network_access_enabled
+  public_network_access_enabled = local.public_network_access_enabled
 
   network_rule_set {
-    public_network_access_enabled = var.public_network_access_enabled
+    public_network_access_enabled = local.public_network_access_enabled
 
     # The only allowed value for 'default_action' is "Allow" if no 'ip_rules' or 'network_rules' is set.
     default_action           = length(var.network_rule_set_ip_rules) == 0 && length(var.network_rule_set_virtual_network_rules) == 0 ? "Allow" : "Deny"

--- a/tests/networking.unit.tftest.hcl
+++ b/tests/networking.unit.tftest.hcl
@@ -189,8 +189,7 @@ run "network_rule_set_ip_rules" {
 
     sku = "Premium"
 
-    public_network_access_enabled = true
-    network_rule_set_ip_rules     = ["1.1.1.1/32", "2.2.2.2/32", "3.3.3.3/31"]
+    network_rule_set_ip_rules = ["1.1.1.1/32", "2.2.2.2/32", "3.3.3.3/31"]
   }
 
   assert {
@@ -230,7 +229,6 @@ run "network_rule_set_virtual_network_rules" {
 
     sku = "Premium"
 
-    public_network_access_enabled = true
     network_rule_set_virtual_network_rules = [
       {
         subnet_id = run.setup_tests.subnet_ids[0]

--- a/variables.tf
+++ b/variables.tf
@@ -55,10 +55,10 @@ variable "premium_messaging_partitions" {
 }
 
 variable "public_network_access_enabled" {
-  description = "Is public network access enabled for the Service Bus namespace?"
+  description = "Is public network access enabled for the Service Bus namespace? If value is null, public network access will be implicitly enabled if one or more IP or virtual network rules are configured."
   type        = bool
-  default     = false
-  nullable    = false
+  default     = null
+  nullable    = true
 }
 
 variable "system_assigned_identity_enabled" {


### PR DESCRIPTION
Implicitly enable public network access if one or more IP or virtual network rules are configured:

- Add local value `public_network_access_enabled` for implicitly enabling public network access if it has not been explicitly enabled.
- Update any direct references to `var.public_network_access_enabled` to reference `local.public_network_access_enabled` instead.
- Update tests to not explicitly enable public network access if not required. **No assert blocks have been modified, so tests work exactly as before**.